### PR TITLE
Add a placeholder page for the list of plugins

### DIFF
--- a/plugins/index.html
+++ b/plugins/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>List of Embulk Plugins by Category</title>
+    <link rel="stylesheet" href="../docs/_static/haiku.css" type="text/css" />
+    <link rel="stylesheet" href="../docs/_static/pygments.css" type="text/css" />
+    <link rel="top" title="Embulk documentation" href="https://www.embulk.org/docs/index.html" />
+  </head>
+  <body>
+    <div class="header"><h1 class="heading"><a href="https://www.embulk.org/docs/index.html">
+        <span>Embulk plugins</span></a></h1>
+      <h2 class="heading"><span>Embulk plugins by category</span></h2>
+    </div>
+
+    <div class="content">
+      <div class="section">
+        <h1>Moved</h1>
+        <p>The list of Plugins by Category has been moved to <a href="https://plugins.embulk.org/">https://plugins.embulk.org/</a>.</p>
+      </div>
+    </div>
+
+    <div class="footer">
+        &copy; Copyright 2015-2018, The Embulk project.
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Unlike https://github.com/embulk/embulk/pull/1084, files under `/plugins` are not upgraded from `embulk-docs`. We need a placeholder page for users who directly accesses this URL.

Can you have a look? @sakama @kamatama41 